### PR TITLE
feat: Wrap GitHub API body and not return result of comment invocation

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/carbon

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -40,7 +40,9 @@ describe('assignAfterReviewSubmitted', () => {
     })
 
     expect(addAssigneesToIssue).toHaveBeenCalled()
-    expect(addAssigneesToIssue).toHaveBeenCalledWith({ assignees: ['foo'] })
+    expect(addAssigneesToIssue).toHaveBeenCalledWith({
+      body: { assignees: ['foo'] }
+    })
 
     expect(createComment).not.toHaveBeenCalled()
   })

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -41,7 +41,7 @@ describe('assignAfterReviewSubmitted', () => {
 
     expect(addAssigneesToIssue).toHaveBeenCalled()
     expect(addAssigneesToIssue).toHaveBeenCalledWith({
-      body: { assignees: ['foo'] }
+      assignees: ['foo']
     })
 
     expect(createComment).not.toHaveBeenCalled()

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ async function assignAfterReviewSubmitted (context) {
   }
 
   if (config.assignPullRequestOwner) {
-    const params = context.issue({ assignees: [pullRequestOwner] })
+    const params = context.issue({ body: { assignees: [pullRequestOwner] } })
     await github.issues.addAssigneesToIssue(params)
 
     if (config.unassignReviewer) {
@@ -42,7 +42,7 @@ async function assignAfterReviewSubmitted (context) {
 
   if (config.leaveComment) {
     const commentParams = context.issue({ body: comment })
-    return github.issues.createComment(commentParams)
+    await github.issues.createComment(commentParams)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ async function assignAfterReviewSubmitted (context) {
   }
 
   if (config.assignPullRequestOwner) {
-    const params = context.issue({ body: { assignees: [pullRequestOwner] } })
+    const params = context.issue({ assignees: [pullRequestOwner] })
     await github.issues.addAssigneesToIssue(params)
 
     if (config.unassignReviewer) {


### PR DESCRIPTION
@jiminycricket please help review thanks

原來想要把 `addAssigneesToIssue` 的參數用 `body: { ... }` 包起來，最後發現 [node-github 的文件](https://octokit.github.io/node-github/#api-issues-addAssigneesToIssue) 就沒有 `body` 參數，也就是用 `body: { ... }` 包起來反而會錯

...所以最後就變成加個 `.nvmrc` 跟拿掉最後的 `return` statement 而已 😝